### PR TITLE
Add hurricane response project page, plus minor updates.

### DIFF
--- a/pages/about.md
+++ b/pages/about.md
@@ -6,7 +6,7 @@
   leadership:
     -
       name: Ryan Harvey
-      title: Co-Captain and Data Wrangler
+      title: Brigade Captain and Data Wrangler
       image: /img/people/ryan.jpg
       links:
         -
@@ -27,7 +27,7 @@
         Ryan grew up in the New Orleans area, graduated from Loyola University in uptown, and works remotely as a data engineer for TED Conferences. He also serves as an adjunct lecturer in computer science at Loyola. Ryan lives in a multi-generational home in Mandeville, and has two amazing kids.
     -
       name: Marc Cenac
-      title: Co-Captain and Community Organizer
+      title: Brigade Founder and Community Organizer
       image: /img/people/marc.jpg
       links:
         -

--- a/pages/join.md
+++ b/pages/join.md
@@ -18,7 +18,7 @@ After a year and a half or so on Meetup, we have over 300 members in our group. 
 
 Many of our attendees are learning-stage software developers, looking to hone their skills through our civic-minded projects. We're excited to support and mentor them, and through that, help strengthen our city's tech community. In addition, technologists with a range of skills beyond coding like designers, project managers, and data analysts attend our events.
 
-Over the past year and a half, we’ve worked to improve the accuracy of the city's public 311 services data; begun to visualize that 311 data in useful and meaningful ways; explored new ideas for engaging the general public with Tulane University's Design Thinking students; explored ideas for building a common city-wide user interface component to handle street address auto-completion; built a scraper for the city assessor's property tax data; and worked to make RTA's transit data more accessible to New Orleans residents.
+Over the past couple years, we’ve worked to improve the accuracy of the city's public 311 services data; begun to visualize that 311 data in useful and meaningful ways; explored new ideas for engaging the general public with Tulane University's Design Thinking students; explored ideas for building a common city-wide user interface component to handle street address auto-completion; built a scraper for the city assessor's property tax data; worked to make RTA's transit data more accessible to New Orleans residents; and worked collaboratively with others around the country to assist hurricane response efforts.
 
 #### Donate Your Time and Effort
 

--- a/pages/projects/hurricane-response.md
+++ b/pages/projects/hurricane-response.md
@@ -1,0 +1,54 @@
+---
+  layout: code_for_new_orleans_project
+  title: Hurricane Response
+  category: project
+  project:
+    champion:
+      name: Ryan Harvey
+      email: ryan@codeforneworleans.org
+    people:
+      -
+        name: Ryan Harvey
+        title: API Lead
+      -
+        name: Michael Bishop (Code for Tampa Bay)
+        title: Front-end Lead
+      -
+        name: Christopher Whitaker (Code for America)
+        title: Coordinator
+    goals:
+      - Provide tools to support just-in-time information delivery to residents of storm-affected areas in need of shelters, food and water
+      - Support information collection to ensure information delivered is up-to-date and matches of the on-the-ground response
+    skills_needed:
+      - Ruby
+      - Ruby on Rails
+      - Front-end web development
+      - Jekyll/Liquid template scripting
+      - User experience
+      - SMS text message bot
+      - Information collection (call bank)
+      - Volunteer management & engagement
+      - Amateur packet radio & low-power/resource-limited communications
+    why: |
+      As folks in New Orleans know, hurricanes and their aftermath can be difficult and stressful times for all. Our goal is to make finding initial basic needs (shelter, food, and water) as frustration-free as possible.
+
+      Unfortunately, with information released individually by cities, towns, counties and states in varying formats and at varying web addresses, finding information that pertains to you can be a difficult task, despite efforts to the contrary.
+      
+      This project is a multi-brigade effort to provide technology and information support for hurricane response efforts led by FEMA in collaboration with other volunteer organizations.
+
+      The effort began when the Sketch City brigade in Houston organized a response effort for Hurricane Harvey in 2017. Following that, the technology has been improved and redeployed for Hurricane Irma in 2017 and Hurricanes Florence and Michael in 2018.
+
+      Between responses, we work on the technology platform to ensure we can respond quickly and efficiently when a storm comes, and we hope to improve the platform to support other response characteristics and other disaster types.
+
+      During a response, we manage operational issues and try to make information updates as smooth for our call bank volunteers as possible. We also keep up-to-date on official shelter and distribution point lists released by affected cities, counties and states, and ensure our database's information matches those. When it doesn't, we determine the state on the ground to the best of our ability and either update our database or feed that information upstream to the affected areas and FEMA (or both). Finally, we often get involved in calling shelters and distribution points, as ensuring data is current and accurate is top priority.
+    where: |
+      To get started with this effort, your best starting point is [this Google doc](https://bit.ly/2N6YVYD).
+
+      In addition, you'll want to join the **#hurricane_api** channel in the Code for America Slack. [You can get a self-invite here.](https://docs.google.com/forms/d/e/1FAIpQLSfRqy9L8Z5bS8cPHmHrY6BPT5g6K45uo0Z3KicYLB4bsFp2wA/viewform)
+      
+      Hurricane response app code is located on Github in the [hurricane-response organization](https://github.com/hurricane-response).
+
+      The API is in [hurricane-response/florence-api](http://github.com/florence-api).
+
+      The front-end template is in [hurricane-response/response-theme](https://github.com/hurricane-response/response-theme).
+---


### PR DESCRIPTION
This PR does the following:

- adds a project page for hurricane response work
- modifies titles on the About page
- modifies the "Small, But Mighty" section of the Join page to mention hurricane response work
