### PR TITLE
Update “Donate” page link

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -18,7 +18,7 @@
             </a></li>
           {% endif %}
         {% endfor %}
-            <li class='cta'><a href='https://secure.codeforamerica.org/page/contribute/donate-to-a-brigade-today?source_codes=codeforneworleans.org&brigade=Code%20for%20New%20Orleans' target='_blank'><strong>Donate</strong></a></li>
+            <li class='cta'><a href='https://www.codeforamerica.org/donate-to-a-brigade?utm_campaign=Code%20for%20New%20Orleans&utm_source=codeforneworleans.org' target='_blank'><strong>Donate</strong></a></li>
       </ul>
     </nav>
   </header>


### PR DESCRIPTION
We at Code for America created this new donate page [seven months
ago][1] because the old donate page required a high maintenance
burden and created an unnecessary duplication in our process.

This commit updates your website to link to the new Donate page.

[1]: https://groups.google.com/a/codeforamerica.org/g/brigadeleads/c/At0loymFW0I/m/OVC-W90yEAAJ